### PR TITLE
feat: 카메라 및 갤러리 연동 기능 추가

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-06-09T05:02:57.843514600Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\whtnd\.android\avd\TermProject.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.firebase.firestore.ktx)
+    implementation(libs.firebase.storage.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,10 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" /> <!-- API 33 이상 -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"
@@ -34,6 +41,15 @@
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>
         <meta-data android:name="com.google.android.maps.v2.API_KEY" android:value="${MAPS_API_KEY}"/>
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/res/layout/activity_write.xml
+++ b/app/src/main/res/layout/activity_write.xml
@@ -1,117 +1,173 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 일기 작성 화면 -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#F4F5FB"
-    tools:context=".MainActivity">
+    tools:context=".WriteActivity">
 
+    <!-- 제목 -->
     <EditText
         android:id="@+id/diaryTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="30dp"
+        android:background="@null"
         android:fontFamily="@font/kakaobigsans_bold"
-        android:gravity="start"
         android:hint="오늘은 어떤 제목이 좋을까요"
         android:inputType="text"
         android:maxLength="30"
-        android:paddingStart="15dp"
-        android:paddingTop="10dp"
-        android:paddingBottom="10dp"
-        android:textSize="25sp"
         android:maxLines="1"
+        android:paddingStart="15dp"
+        android:paddingTop="15dp"
+        android:paddingBottom="0dp"
         android:scrollHorizontally="true"
-        android:background="@null"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:textSize="25sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.1"
         app:layout_constraintWidth_percent="0.9" />
+
+    <!-- 위치 선택 버튼 -->
+    <Button
+        android:id="@+id/btnPickOnMap"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="위치 선택"
+        android:textSize="16sp"
+        android:background="@drawable/black_square_button"
+        android:textColor="@color/white"
+        android:layout_marginTop="5dp"
+        app:layout_constraintTop_toBottomOf="@id/diaryTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintWidth_percent="0.9" />
+
+    <!-- 카메라 / 갤러리 버튼 -->
+    <LinearLayout
+        android:id="@+id/photoPanel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="5dp"
+        app:layout_constraintTop_toBottomOf="@id/btnPickOnMap"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintWidth_percent="0.9">
+
+        <Button
+            android:id="@+id/btnCamera"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="사진 찍기"
+            android:textSize="16sp"
+            android:textColor="@color/white"
+            android:background="@drawable/black_square_button" />
+
+        <Button
+            android:id="@+id/btnGallery"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="갤러리"
+            android:textSize="16sp"
+            android:textColor="@color/white"
+            android:background="@drawable/black_square_button" />
+    </LinearLayout>
+
+    <!-- 이미지 미리보기 -->
+    <ImageView
+        android:id="@+id/imagePreview"
+        android:layout_width="0dp"
+        android:layout_height="200dp"
+        android:layout_marginBottom="2dp"
+        android:contentDescription="선택된 사진"
+        android:scaleType="centerCrop"
+        android:src="@drawable/ic_launcher_background"
+        app:layout_constraintBottom_toTopOf="@+id/diaryLayout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/photoPanel"
+        app:layout_constraintWidth_percent="0.9" />
+
+    <!-- 일기 내용 입력 -->
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/diaryLayout"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintWidth_percent="0.9"
-        app:layout_constraintHeight_percent="0.7"
-        app:layout_constraintTop_toBottomOf="@+id/diaryTitle"
-        app:layout_constraintBottom_toTopOf="@+id/buttonPanel"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="5dp"
+        android:hint="당신의 오늘을 기록해주세요"
         app:boxBackgroundMode="outline"
         app:boxStrokeColor="@color/black"
         app:hintTextColor="@color/black"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:hint="당신의 오늘을 기록해주세요">
-    <com.google.android.material.textfield.TextInputEditText
-        android:id="@+id/diaryContent"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fontFamily="@font/kakaobigsans_bold"
-        android:inputType="textMultiLine"
-        android:gravity="start"
-        android:maxLength="5000"
-        android:paddingTop="10dp"
-        android:paddingBottom="10dp"
-        android:textSize="18sp"
-        app:counterEnabled="false"
-        android:textColor="@color/black" />
+        app:layout_constraintTop_toBottomOf="@id/imagePreview"
+        app:layout_constraintBottom_toTopOf="@id/buttonPanel"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintWidth_percent="0.9"
+        app:layout_constraintHeight_percent="0.3">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/diaryContent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fontFamily="@font/kakaobigsans_bold"
+            android:inputType="textMultiLine"
+            android:textSize="18sp"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp"
+            android:maxLength="5000"
+            android:textColor="@color/black"
+            android:gravity="start" />
     </com.google.android.material.textfield.TextInputLayout>
-    <EditText
-        android:id="@+id/editLocation"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="장소를 입력하세요 (예: 서울시 강남구)"
-        android:padding="12dp"
-        android:textSize="16sp"
-        android:layout_marginTop="12dp"
-        tools:ignore="MissingConstraints" />
+
+    <!-- 하단 버튼들 -->
     <LinearLayout
         android:id="@+id/buttonPanel"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="5dp"
+        app:layout_constraintTop_toBottomOf="@id/diaryLayout"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/diaryLayout"
-        app:layout_constraintWidth_percent="0.9"
-        >
-        <Button
-            android:id="@+id/saveButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/white"
-            android:textSize="20sp"
-            android:fontFamily="@font/kakaosmallsans_bold"
-            app:backgroundTint="@null"
-            android:background="@drawable/black_square_button"
-            android:text="완료"
-            android:layout_weight="1"/>
-        <Button
-            android:id="@+id/draftButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/white"
-            android:textSize="20sp"
-            android:fontFamily="@font/kakaosmallsans_bold"
-            app:backgroundTint="@null"
-            android:background="@drawable/black_square_button"
-            android:text="임시 저장"
-            android:layout_weight="1"/>
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintWidth_percent="0.9">
+
         <Button
             android:id="@+id/deleteButton"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:textColor="@color/white"
-            android:textSize="20sp"
-            android:fontFamily="@font/kakaosmallsans_bold"
-            app:backgroundTint="@null"
-            android:background="@drawable/black_square_button"
+            android:layout_weight="1"
             android:text="삭제"
-            android:layout_weight="1"/>
+            android:textSize="18sp"
+            android:textColor="@color/white"
+            android:background="@drawable/black_square_button" />
+
+        <Button
+            android:id="@+id/draftButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="임시 저장"
+            android:textSize="18sp"
+            android:textColor="@color/white"
+            android:background="@drawable/black_square_button" />
+
+        <Button
+            android:id="@+id/saveButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="완료"
+            android:textSize="18sp"
+            android:textColor="@color/white"
+            android:background="@drawable/black_square_button" />
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="camera" path="." />
+</paths>


### PR DESCRIPTION
## ✨ 작업 내용
- activity_write에서 사진 미리보기 및 사진 첨부 버튼 추가
- 카메라 앱 실행 → 촬영 후 사진 미리보기 가능
- 갤러리에서 사진 선택 후 미리보기 가능
- WriteActivity에서 사진 첨부 기능 구현

## 🛠 변경 사항
- activity_write.xml에 imagePreview, 버튼 추가
- FileProvider 설정 (AndroidManifest.xml + file_paths.xml)
- API 33 이상 대응을 위한 권한 분기 처리

## ✅ 테스트 방법
- 카메라 앱에서 사진 촬영 → WriteActivity로 되돌아오는지 확인
<img src="https://github.com/user-attachments/assets/6b837716-786c-4353-8f9a-0e30f8c5e938" width="250px">
<img src="https://github.com/user-attachments/assets/ee551d0d-3c50-4fe4-9166-673b5962b82f" width="250px">
<img src="https://github.com/user-attachments/assets/24df80e3-930b-4929-9305-199323ec50c9" width="250px">

- 갤러리에서 사진 선택 → 미리보기 정상 출력
<img src="https://github.com/user-attachments/assets/fd91f0c3-48fa-4874-8367-adbe402ed98e" width="250px">
<img src="https://github.com/user-attachments/assets/28f8fe53-1727-4449-b576-0ca540f8a5ef" width="250px">

## 📌 참고
- Android 13 이상에서는 READ_MEDIA_IMAGES 권한 필요
- Android 12 이하에서는 READ_EXTERNAL_STORAGE 사용
